### PR TITLE
Improve Docker compose with volumes binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ app.env.*
 
 # Log files
 *.log
+
+# Temporary files
+tmp

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ run: build
 	simplebank:latest
 
 containers:
+	mkdir -p tmp/pgdata
+	mkdir -p tmp/redisdata
 	docker compose -f docker-compose.yaml up -d --build
 
 # TOKEN_SYMMETRIC_KEY generator

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ make test
 
 Complete the necessary environment variables in the app.env (copy from [app.env.example](/app.env.example)) file.
 
-The following command will run the [docker-compose.yaml](docker-compose.yaml) file
+The following command will create PosgreSQL and Redis volume data in [tmp](tmp) directory and run the [docker-compose.yaml](docker-compose.yaml) file with build in detach mode.
 
 ```bash
 make containers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=simplebank
+    volumes:
+      - pg-data:/var/lib/postgresql/data
 
   redis:
     container_name: simplebank-redis
@@ -18,6 +20,8 @@ services:
       - "6379:6379"
     networks:
       - simplebank-net
+    volumes:
+      - redis-data:/data
 
   api:
     build:
@@ -51,3 +55,19 @@ networks:
   simplebank-net:
       name: simplebank-net
       external: false
+
+volumes:
+  pg-data:
+    name: simplebank-pg-data
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: ./tmp/pgdata
+  redis-data:
+    name: simplebank-redis-data
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: ./tmp/redisdata


### PR DESCRIPTION
# Request for Change (RFC)

Based on the need to provide persistent data container options, especially PostgreSQL and Redis, in the Docker compose configuration, I added volume bindings settings.

## Changes

- Added a `tmp` directory to store containers' volume data
- Added [Docker compose volume](https://docs.docker.com/reference/compose-file/volumes/#example) bindings configuration into the relative path of the project
  - use follows https://hub.docker.com/_/postgres#pgdata and https://hub.docker.com/_/redis#start-with-persistent-storage
- Updated necessary clarity on how to start the services using the `docker-compose.yaml` file and what the command will do 

## Testing Instructions

Run `make containers` and the Docker engine will establish Docker volumes for the PostgreSQL and Redis services
