### PR TITLE
Gracefully shutdown servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ Thank you for watching!
 
 Simple Bank Service is a comprehensive banking API that provides secure account management, money transfers, and user authentication with email verification.
 
-**Key responsibilities:**
+### Key Responsibilities
 
 - Create and manage bank accounts, which are composed of the owner’s name, balance, and currency.
 - Record all balance changes to each of the accounts. So every time some money is added to or subtracted from the account, an account entry record will be created.
 - Perform a money transfer between 2 accounts. This should happen within a transaction, so that either both accounts' balances are updated successfully or none of them are.
 - Handle user registration, authentication, and email verification
 
-TODO features including:
+**TODO APIs including:**
 
 1. Top up a balance account through a payment gateway such as Midtrans.
 2. Release the balance from an account in the booking-action schema.
+
+### Features
+
+- **Graceful shutdown**: It can stop receiving new requests, and wait for all on-going requests to be completed before shutting down (related issue [#28](https://github.com/ymanshur/simplebank/issues/28))
 
 ## Architecture Overview
 

--- a/api/server.go
+++ b/api/server.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
+	"github.com/rs/zerolog/log"
 	db "github.com/ymanshur/simplebank/db/sqlc"
 	"github.com/ymanshur/simplebank/pkg/token"
 	"github.com/ymanshur/simplebank/pkg/util"
@@ -17,6 +20,7 @@ type Server struct {
 	store      db.Store
 	tokenMaker token.Maker
 	router     *gin.Engine
+	http       *http.Server
 }
 
 // NewServer creates a new HTTP server and set up routing.
@@ -65,7 +69,27 @@ func (server *Server) setupRouter() {
 
 // Start runs the HTTP server on a specific address.
 func (server *Server) Start(address string) error {
-	return server.router.Run(address)
+	server.http = &http.Server{
+		Addr:    address,
+		Handler: server.router.Handler(),
+	}
+
+	log.Info().Msgf("start HTTP server at %s", server.http.Addr)
+
+	return server.http.ListenAndServe()
+}
+
+func (server *Server) Shutdown() error {
+	log.Info().Msg("graceful shutdown HTTP gateway server")
+
+	err := server.http.Shutdown(context.Background())
+	if err != nil {
+		return err
+	}
+
+	log.Info().Msg("HTTP server is stopped")
+
+	return nil
 }
 
 func errorResponse(err error) gin.H {

--- a/gapi/server.go
+++ b/gapi/server.go
@@ -1,6 +1,7 @@
 package gapi
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -23,6 +24,7 @@ type Server struct {
 	store           db.Store
 	tokenMaker      token.Maker
 	rpc             *grpc.Server
+	gateway         *http.Server
 	taskDistributor worker.TaskDistributor
 }
 
@@ -58,16 +60,38 @@ func (server *Server) Start(address string) error {
 	}
 
 	log.Info().Msgf("start gRPC server at %s", listener.Addr().String())
+
 	return server.rpc.Serve(listener)
 }
 
+func (server *Server) Shutdown() {
+	log.Info().Msg("graceful shutdown gRPC server")
+
+	server.rpc.GracefulStop()
+
+	log.Info().Msg("gRPC server is stopped")
+}
+
 func (server *Server) StartGateway(address string, mux *http.ServeMux) error {
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		log.Fatal().Err(err).Msg("cannot create listener")
+	server.gateway = &http.Server{
+		Addr:    address,
+		Handler: HttpLogger(mux),
 	}
 
-	log.Info().Msgf("start HTTP gateway server at %s", listener.Addr().String())
-	handler := HttpLogger(mux)
-	return http.Serve(listener, handler)
+	log.Info().Msgf("start HTTP gateway server at %s", server.gateway.Addr)
+
+	return server.gateway.ListenAndServe()
+}
+
+func (server *Server) ShutdownGateway() error {
+	log.Info().Msg("graceful shutdown HTTP gateway server")
+
+	err := server.gateway.Shutdown(context.Background())
+	if err != nil {
+		return err
+	}
+
+	log.Info().Msg("HTTP gateway server is stopped")
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -30,6 +32,12 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+var interuptSignals = []os.Signal{
+	os.Interrupt,
+	syscall.SIGTERM,
+	syscall.SIGINT,
+}
+
 func main() {
 	config, err := util.LoadConfig(".")
 	if err != nil {
@@ -47,7 +55,8 @@ func main() {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), interuptSignals...)
+	defer stop()
 
 	conn, err := pgxpool.New(ctx, config.DBSource)
 	if err != nil {
@@ -66,13 +75,12 @@ func main() {
 
 	taskDistributor := worker.NewRedisTaskDistributor(redisOpt)
 
-	go runTaskProcessor(config, redisOpt, store)
-
 	wg, ctx := errgroup.WithContext(ctx)
 
-	runGinServer(wg, config, store)
-	runGrpcServer(wg, config, store, taskDistributor)
-	runGrpcGatewayServer(wg, config, store, taskDistributor)
+	runTaskProcessor(ctx, wg, config, redisOpt, store)
+	runGinServer(ctx, wg, config, store)
+	runGrpcServer(ctx, wg, config, store, taskDistributor)
+	runGrpcGatewayServer(ctx, wg, config, store, taskDistributor)
 
 	err = wg.Wait()
 	if err != nil {
@@ -93,7 +101,7 @@ func runDBMigration(migrationURL string, dbSource string) {
 	log.Info().Msg("db migrated successfully")
 }
 
-func runTaskProcessor(config util.Config, redisOpt asynq.RedisClientOpt, store db.Store) {
+func runTaskProcessor(ctx context.Context, waitGroup *errgroup.Group, config util.Config, redisOpt asynq.RedisClientOpt, store db.Store) {
 	mailer := mail.NewGmailSender(config.EmailSenderName, config.EmailSenderAddress, config.EmailSenderPassword)
 
 	taskProcessor := worker.NewRedisTaskProcessor(config, redisOpt, store, mailer)
@@ -103,9 +111,21 @@ func runTaskProcessor(config util.Config, redisOpt asynq.RedisClientOpt, store d
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to start task processor")
 	}
+
+	waitGroup.Go(func() error {
+		<-ctx.Done()
+
+		log.Info().Msg("graceful shutdown task processor")
+
+		taskProcessor.Shutdown()
+
+		log.Info().Msg("task processor is stopped")
+
+		return nil
+	})
 }
 
-func runGrpcServer(waitGroup *errgroup.Group, config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
+func runGrpcServer(ctx context.Context, waitGroup *errgroup.Group, config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
 	server, err := gapi.NewServer(config, store, taskDistributor)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot create gRPC server")
@@ -116,11 +136,20 @@ func runGrpcServer(waitGroup *errgroup.Group, config util.Config, store db.Store
 		if err != nil {
 			return fmt.Errorf("cannot start gRPC server: %v", err)
 		}
+
+		return nil
+	})
+
+	waitGroup.Go(func() error {
+		<-ctx.Done()
+
+		server.Shutdown()
+
 		return nil
 	})
 }
 
-func runGrpcGatewayServer(waitGroup *errgroup.Group, config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
+func runGrpcGatewayServer(ctx context.Context, waitGroup *errgroup.Group, config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
 	server, err := gapi.NewServer(config, store, taskDistributor)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot create server")
@@ -136,9 +165,6 @@ func runGrpcGatewayServer(waitGroup *errgroup.Group, config util.Config, store d
 	})
 
 	grpcMux := runtime.NewServeMux(jsonOption)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	err = pb.RegisterSimpleBankHandlerServer(ctx, grpcMux, server)
 	if err != nil {
@@ -161,12 +187,24 @@ func runGrpcGatewayServer(waitGroup *errgroup.Group, config util.Config, store d
 		if err != nil {
 			return fmt.Errorf("cannot start HTTP gateway server: %v", err)
 		}
+
+		return nil
+	})
+
+	waitGroup.Go(func() error {
+		<-ctx.Done()
+
+		err = server.ShutdownGateway()
+		if err != nil {
+			return fmt.Errorf("cannot graceful shutdown HTTP gateway server: %v", err)
+		}
+
 		return nil
 	})
 }
 
-func runGinServer(waitGroup *errgroup.Group, config util.Config, store db.Store) {
-	server, err := api.NewServer(util.Config{}, store)
+func runGinServer(ctx context.Context, waitGroup *errgroup.Group, config util.Config, store db.Store) {
+	server, err := api.NewServer(config, store)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot create HTTP server")
 	}
@@ -176,6 +214,18 @@ func runGinServer(waitGroup *errgroup.Group, config util.Config, store db.Store)
 		if err != nil {
 			return fmt.Errorf("cannot start HTTP server: %v", err)
 		}
+
+		return nil
+	})
+
+	waitGroup.Go(func() error {
+		<-ctx.Done()
+
+		err = server.Shutdown()
+		if err != nil {
+			return fmt.Errorf("cannot graceful shutdown HTTP server: %v", err)
+		}
+
 		return nil
 	})
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"os"
 	"os/signal"
@@ -29,6 +29,7 @@ import (
 	"github.com/ymanshur/simplebank/pb"
 	"github.com/ymanshur/simplebank/pkg/util"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -107,6 +108,7 @@ func runTaskProcessor(ctx context.Context, waitGroup *errgroup.Group, config uti
 	taskProcessor := worker.NewRedisTaskProcessor(config, redisOpt, store, mailer)
 
 	log.Info().Msg("start task processor")
+
 	err := taskProcessor.Start()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to start task processor")
@@ -134,7 +136,13 @@ func runGrpcServer(ctx context.Context, waitGroup *errgroup.Group, config util.C
 	waitGroup.Go(func() error {
 		err = server.Start(config.GRPCServerAddress)
 		if err != nil {
-			return fmt.Errorf("cannot start gRPC server: %v", err)
+			if errors.Is(err, grpc.ErrServerStopped) {
+				return nil
+			}
+
+			log.Error().Err(err).Msg("cannot start gRPC server")
+
+			return err
 		}
 
 		return nil
@@ -185,7 +193,13 @@ func runGrpcGatewayServer(ctx context.Context, waitGroup *errgroup.Group, config
 	waitGroup.Go(func() error {
 		err = server.StartGateway(config.GRPCGatewayServerAddress, mux)
 		if err != nil {
-			return fmt.Errorf("cannot start HTTP gateway server: %v", err)
+			if errors.Is(err, http.ErrServerClosed) {
+				return nil
+			}
+
+			log.Error().Err(err).Msg("cannot start HTTP gateway server")
+
+			return err
 		}
 
 		return nil
@@ -196,7 +210,9 @@ func runGrpcGatewayServer(ctx context.Context, waitGroup *errgroup.Group, config
 
 		err = server.ShutdownGateway()
 		if err != nil {
-			return fmt.Errorf("cannot graceful shutdown HTTP gateway server: %v", err)
+			log.Error().Err(err).Msg("cannot graceful shutdown HTTP gateway server")
+
+			return err
 		}
 
 		return nil
@@ -212,7 +228,13 @@ func runGinServer(ctx context.Context, waitGroup *errgroup.Group, config util.Co
 	waitGroup.Go(func() error {
 		err = server.Start(config.HTTPServerAddress)
 		if err != nil {
-			return fmt.Errorf("cannot start HTTP server: %v", err)
+			if errors.Is(err, http.ErrServerClosed) {
+				return nil
+			}
+
+			log.Error().Err(err).Msg("cannot start HTTP server")
+
+			return err
 		}
 
 		return nil
@@ -223,7 +245,9 @@ func runGinServer(ctx context.Context, waitGroup *errgroup.Group, config util.Co
 
 		err = server.Shutdown()
 		if err != nil {
-			return fmt.Errorf("cannot graceful shutdown HTTP server: %v", err)
+			log.Error().Err(err).Msg("cannot graceful shutdown HTTP server")
+
+			return err
 		}
 
 		return nil

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/ymanshur/simplebank/gapi"
 	"github.com/ymanshur/simplebank/pb"
 	"github.com/ymanshur/simplebank/pkg/util"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -45,7 +47,9 @@ func main() {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
-	conn, err := pgxpool.New(context.Background(), config.DBSource)
+	ctx := context.Background()
+
+	conn, err := pgxpool.New(ctx, config.DBSource)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot connect to db:")
 	}
@@ -63,9 +67,17 @@ func main() {
 	taskDistributor := worker.NewRedisTaskDistributor(redisOpt)
 
 	go runTaskProcessor(config, redisOpt, store)
-	go runGinServer(config, store)
-	go runGrpcServer(config, store, taskDistributor)
-	runGrpcGatewayServer(config, store, taskDistributor)
+
+	wg, ctx := errgroup.WithContext(ctx)
+
+	runGinServer(wg, config, store)
+	runGrpcServer(wg, config, store, taskDistributor)
+	runGrpcGatewayServer(wg, config, store, taskDistributor)
+
+	err = wg.Wait()
+	if err != nil {
+		log.Fatal().Err(err)
+	}
 }
 
 func runDBMigration(migrationURL string, dbSource string) {
@@ -93,19 +105,22 @@ func runTaskProcessor(config util.Config, redisOpt asynq.RedisClientOpt, store d
 	}
 }
 
-func runGrpcServer(config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
+func runGrpcServer(waitGroup *errgroup.Group, config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
 	server, err := gapi.NewServer(config, store, taskDistributor)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot create gRPC server")
 	}
 
-	err = server.Start(config.GRPCServerAddress)
-	if err != nil {
-		log.Fatal().Err(err).Msg("cannot start gRPC server")
-	}
+	waitGroup.Go(func() error {
+		err = server.Start(config.GRPCServerAddress)
+		if err != nil {
+			return fmt.Errorf("cannot start gRPC server: %v", err)
+		}
+		return nil
+	})
 }
 
-func runGrpcGatewayServer(config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
+func runGrpcGatewayServer(waitGroup *errgroup.Group, config util.Config, store db.Store, taskDistributor worker.TaskDistributor) {
 	server, err := gapi.NewServer(config, store, taskDistributor)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot create server")
@@ -141,20 +156,26 @@ func runGrpcGatewayServer(config util.Config, store db.Store, taskDistributor wo
 	swaggerHandler := http.StripPrefix("/swagger/", http.FileServer(fs))
 	mux.Handle("/swagger/", swaggerHandler)
 
-	err = server.StartGateway(config.GRPCGatewayServerAddress, mux)
-	if err != nil {
-		log.Fatal().Err(err).Msg("cannot start HTTP gateway server")
-	}
+	waitGroup.Go(func() error {
+		err = server.StartGateway(config.GRPCGatewayServerAddress, mux)
+		if err != nil {
+			return fmt.Errorf("cannot start HTTP gateway server: %v", err)
+		}
+		return nil
+	})
 }
 
-func runGinServer(config util.Config, store db.Store) {
-	server, err := api.NewServer(config, store)
+func runGinServer(waitGroup *errgroup.Group, config util.Config, store db.Store) {
+	server, err := api.NewServer(util.Config{}, store)
 	if err != nil {
 		log.Fatal().Err(err).Msg("cannot create HTTP server")
 	}
 
-	err = server.Start(config.HTTPServerAddress)
-	if err != nil {
-		log.Fatal().Err(err).Msg("cannot start HTTP server")
-	}
+	waitGroup.Go(func() error {
+		err = server.Start(config.HTTPServerAddress)
+		if err != nil {
+			return fmt.Errorf("cannot start HTTP server: %v", err)
+		}
+		return nil
+	})
 }

--- a/pkg/worker/processor.go
+++ b/pkg/worker/processor.go
@@ -18,6 +18,7 @@ const (
 
 type TaskProcessor interface {
 	Start() error
+	Shutdown()
 	ProcessTaskSendVerifyEmail(ctx context.Context, task *asynq.Task) error
 }
 
@@ -65,4 +66,8 @@ func (processor *RedisTaskProcessor) Start() error {
 	mux.HandleFunc(TaskSendVerifyEmail, processor.ProcessTaskSendVerifyEmail)
 
 	return processor.server.Start(mux)
+}
+
+func (processor *RedisTaskProcessor) Shutdown() {
+	processor.server.Shutdown()
 }


### PR DESCRIPTION
# Request for Change (RFC)

When we attempt to stop the server, it is still processing a request that takes a considerable amount of time to complete. The server still stops immediately, and it doesn’t wait for the request to complete.

This can happen anytime you deploy new code to the server, and if your server has high traffic, a lot of ongoing requests can be interrupted just like that.

And it can also happen to ongoing asynchronous tasks.

That’s why we need to add graceful shutdowns to our servers, so they can **stop receiving new requests or tasks**, and **wait for all ongoing requests to be completed** before shutting down.

- Fixes #28 

## Changes

When an application receives a signal to terminate, it should perform a series of steps to ensure a smooth shutdown:

**Signal Handling**: Create a context that listens to SIGINT (Ctrl+C) or SIGTERM (kill command) signals and triggers the graceful shutdown process after the signal within the context is received.

**Blocking Context**:  This context will be used to open different goroutines to shut down their service.

**Cleanup Logic**: Ensure that all servers (task processor, Gin HTTP, gRPC, and gRPC Gateway) are properly closed and released. 

**Wait Group**: Use a `errgroup` package to keep track of running shutdown goroutines. This way, you can wait for all shutdown processes to finish before exiting the application.

## Testing Instructions

Specifically using the create user API because it will trigger the verification email asynchronously

1. Add the logs info that sign
    1. The start of user creation
    2. Before sending the verification email
    3. After the user session is created
    4. User creation is done
2. Add sleep time after **starting user creation**, **user session created** and **before API response** to give the time we terminate the service; If exit code catch up:
    1. At the time after the start of user creation → the server does not accept any request later 

        <img width="1191" height="419" alt="Screenshot 2025-09-12 172440" src="https://github.com/user-attachments/assets/a4f7b1f5-71e2-4bc3-bc7b-cbf11c91a8d2" />
        
        The Error below will appear if the request is made through the REST Client VS Code extension
        
        <img width="475" height="180" alt="Screenshot 2025-09-12 184216" src="https://github.com/user-attachments/assets/333adcd5-c1a8-4655-b44b-27a2ba2984ce" />
        
    2. At the time after the start of sending verification emails → the task is enqueued back to the queue 
        
        <img width="1185" height="481" alt="image" src="https://github.com/user-attachments/assets/ae8fd682-f424-421a-a8e3-b87a91092b78" />

    3. At the time before the API response → it will wait for the server to send the response, marked with log status code 200, before the server stops

        <img width="1177" height="418" alt="Screenshot 2025-09-12 184700" src="https://github.com/user-attachments/assets/f2b0a28f-83ad-470b-be35-a3825fe9c2ab" />

## Notes

Further reference for improvement: [A Deep Dive into Graceful Shutdown in Go by Ivelin Yanev](https://dev.to/yanev/a-deep-dive-into-graceful-shutdown-in-go-484a)
